### PR TITLE
Fix compilation problems on VC++6.0 and MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,11 @@ if (MSVC)
 else (MSVC)
     if (CMAKE_COMPILER_IS_GNUCXX)
         # GCC flags
-        add_definitions(-rdynamic -fstack-protector-all -Wall -Wextra -pedantic -Wformat-security -Winit-self -Wswitch-default -Wswitch-enum -Wfloat-equal -Wshadow -Wcast-qual -Wconversion -Wlogical-op -Winline)
+        if (MINGW)
+            add_definitions(-Wl,--export-all-symbols -fstack-protector -Wall -Wextra -pedantic -Wformat-security -Winit-self -Wswitch-default -Wswitch-enum -Wfloat-equal -Wshadow -Wcast-qual -Wconversion -Wlogical-op -Winline)
+        else (MINGW)
+            add_definitions(-rdynamic -fstack-protector-all -Wall -Wextra -pedantic -Wformat-security -Winit-self -Wswitch-default -Wswitch-enum -Wfloat-equal -Wshadow -Wcast-qual -Wconversion -Wlogical-op -Winline)
+        endif (MINGW)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         # Clang flags
         add_definitions(-fstack-protector-all -Wall -Wextra -pedantic -Wformat-security -Winit-self -Wswitch-default -Wswitch-enum -Wfloat-equal -Wshadow -Wcast-qual -Wconversion -Winline)


### PR DESCRIPTION
This would fix #4.

VC++6.0 does not allow template friend class, so I use the `shared_ptr_base` class to be the parent of all `shared_ptr<T>`, and then `shared_ptr<T>` can access the `pn` member of a `shared_ptr<U>` with its constructor.

MinGW is not compatible with some normal gcc compilation options, so I replace them with the MinGW versions.